### PR TITLE
docs: fix GLG-Mono entry in ecosystem table (it's a font)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ alias pi-home='command pi --session-control --telegram'
 | **[entwurf](https://github.com/junghan0611/entwurf)** | **Presence** | **Telegram bridge — minimal presence bridge** |
 | **[pi-telegram](https://github.com/badlogic/pi-telegram)** | **Transport** | **Production Telegram DM bridge — queue/file/streaming** |
 | [memex-kb](https://github.com/junghan0611/memex-kb) | Knowledge | Legacy document conversion pipeline |
-| [GLG-Mono](https://github.com/junghan0611/GLG-Mono) | Orchestration | OpenClaw bot configurations |
+| [GLG-Mono](https://github.com/junghan0611/GLG-Mono) | Font | Custom monospace programming font |
 | [geworfen](https://github.com/junghan0611/geworfen) | Being | Existence data viewer — WebTUI agenda |
 
 ### Skill Source Repos


### PR DESCRIPTION
## Summary

The `-config` ecosystem table in `README.md` listed **GLG-Mono** as an "Orchestration" layer with the description "OpenClaw bot configurations", but GLG-Mono is actually a custom monospace programming font.

## Change

`README.md` line 203:

```diff
- | [GLG-Mono](https://github.com/junghan0611/GLG-Mono) | Orchestration | OpenClaw bot configurations |
+ | [GLG-Mono](https://github.com/junghan0611/GLG-Mono) | Font         | Custom monospace programming font |
```

## Test plan

- [x] Diff reviewed — single-line change, no other rows affected
- [ ] Verify the new Layer/Description wording matches the desired phrasing for the font

https://claude.ai/code/session_01SbPQ5XXEjwxjDCaMSZPdVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbPQ5XXEjwxjDCaMSZPdVm)_