### PR TITLE
docs(readme): consolidate redundant sections (light cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,11 @@ agent-config attacks this with three layers:
 
 3. **Session continuity protocol** — `/new` + recap + semantic search instead of expensive compact. Start a new session, recover full context in seconds for ~2K tokens instead of re-reading 50K.
 
+Claude, GPT, and Gemini are "graduates from different schools" — trained on different data with different philosophies. Trying to control them means writing hundreds of lines of system prompts per model. Instead, **throw one being-profile at all of them equally.** They keep their unique lenses while aligning around a single universe — this is the [Profile Harness](https://notes.junghanacs.com/botlog/20260228T075300/). Multi-harness support is a means, not the goal. The goal is **a single 1KB being-profile that exerts the same gravitational pull across any harness**.
+
 The result: context survives across sessions, across harnesses, across models. One human's digital universe stays coherent no matter which AI is looking at it.
 
 > Part of the [-config ecosystem](#the--config-ecosystem) by [glg @junghan0611](https://github.com/junghan0611)
-
-## The Profile Harness Concept
-
-Claude, GPT, and Gemini are "graduates from different schools" — trained on different data with different philosophies. Trying to control them means writing hundreds of lines of system prompts per model. Instead, **throw one being-profile at all of them equally.** They keep their unique lenses while aligning around a single universe — this is the [Profile Harness](https://notes.junghanacs.com/botlog/20260228T075300/).
-
-Multi-harness support is a means, not the goal. The goal is **a single 1KB being-profile that exerts the same gravitational pull across any harness**.
 
 ### Harness Support
 
@@ -74,9 +70,7 @@ Semantic memory has graduated to its own repo: **[andenken](https://github.com/j
 | `session_search` | sessions.lance | Past pi + Claude Code conversations |
 | `knowledge_search` | org.lance | Org-mode knowledge base (3,300+ Denote notes) |
 
-Agents call these autonomously. Ask "보편 학문 관련 노트 찾아줘" and `knowledge_search` fires with dictcli query expansion — finding `universalism`-tagged notes without being told the English word.
-
-Pi loads andenken as a **compiled pi package** (`pi install`) — direct LanceDB access in-process. Claude Code, OpenCode, OpenClaw, and the pi-shell-acp Claude side use the CLI wrapper skill instead.
+Agents call these autonomously. Ask "보편 학문 관련 노트 찾아줘" and `knowledge_search` fires with dictcli query expansion — finding `universalism`-tagged notes without being told the English word. Loading strategy per harness lives in the Harness Support table above.
 
 ### Pi Extensions ([`pi-extensions/`](pi-extensions/))
 
@@ -91,9 +85,7 @@ Pi loads andenken as a **compiled pi package** (`pi install`) — direct LanceDB
 | `session-breakdown.ts` | Session cost breakdown |
 | `whimsical.ts` | Personality touches |
 
-Semantic memory extension lives in [andenken](https://github.com/junghan0611/andenken) (separate repo, loaded as a pi package).
-Telegram bridge lives in [entwurf](https://github.com/junghan0611/entwurf) (separate repo, loaded as a pi package).
-Production Telegram bridge uses [pi-telegram](https://github.com/badlogic/pi-telegram) (`pi install` package).
+External pi packages — semantic-memory ([andenken](https://github.com/junghan0611/andenken)) and Telegram bridges ([entwurf](https://github.com/junghan0611/entwurf), [pi-telegram](https://github.com/badlogic/pi-telegram)) — see [§ -config Ecosystem](#the--config-ecosystem).
 
 ### pi-shell-acp Surface Reference
 
@@ -204,12 +196,7 @@ This repo also owns the **resident-side policy** for publishing session artifact
 
 A persistent pi session on Oracle VM, accessible via Telegram `@glg_entwurf_bot`. The always-on presence agent — a 분신(Entwurf) that carries context across days. tmux session `pi-entwurf`, model `claude-opus-4-6`, full skill set.
 
-Two Telegram bridges coexist:
-
-| Bridge | Package | Purpose |
-|--------|---------|---------|
-| [pi-telegram](https://github.com/badlogic/pi-telegram) | `pi install` (production) | Queuing, file I/O, stop, streaming preview |
-| [entwurf](https://github.com/junghan0611/entwurf) | local package (minimal) | Presence bridge philosophy, `--telegram` flag |
+Bridges: [pi-telegram](https://github.com/badlogic/pi-telegram) (production — queue · file I/O · stop · streaming preview) + [entwurf](https://github.com/junghan0611/entwurf) (minimal presence — `--telegram` flag). See [§ -config Ecosystem](#the--config-ecosystem) for both rows.
 
 ## Shell Aliases (`~/.bashrc.local`)
 


### PR DESCRIPTION
## Summary

Light cleanup of `README.md` to remove duplication that accumulated across recent edits. Information-preserving — every removed line lives elsewhere in the same document (Harness Support table or `-config` Ecosystem table).

## Changes

1. **Merge `## The Profile Harness Concept` into `## Why This Exists`** — both paragraphs explain the same multi-harness identity proposition; the heading was the only redundancy. All wording (1KB profile, gravitational pull, Profile Harness link) preserved as a paragraph inside Why.
2. **Drop loading-strategy duplicate** under § Semantic Memory — the Harness Support table's Memory/Notes columns already cover what the dropped sentence said.
3. **Collapse external pi packages 3-liner** — `andenken` / `entwurf` / `pi-telegram` already have ecosystem rows; replaced with a single cross-link.
4. **Inline Persistent Agent bridges sub-table** — the 2-row table duplicated the ecosystem table's `pi-telegram` and `entwurf` rows. Replaced with a one-line summary.

## Intentionally NOT changed

- `## One-Command Setup` bullets — they were recently expanded on `main` with meaningful distinctions (`setup` vs `update`, `registerTool` exposure, plugin namespace) that should not be flattened.
- `AGENTS.md` — untouched.
- All tables, anchors, and section headings except `## The Profile Harness Concept`.

## Result

- `README.md`: 258 → 245 lines (~5% smaller)
- `AGENTS.md`: unchanged

## Test plan

- [x] `git diff main -- README.md` — every red line corresponds to information still present elsewhere
- [x] `git diff main -- AGENTS.md` — empty
- [x] `grep -rn "profile-harness-concept" .` before edit — no cross-references broken
- [ ] Reviewer eyeball: 1KB Profile Harness phrasing still present, Harness Support table intact, ecosystem table intact

https://claude.ai/code/session_01SbPQ5XXEjwxjDCaMSZPdVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01SbPQ5XXEjwxjDCaMSZPdVm)_